### PR TITLE
Skill tree table and mapping template.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # How to contribute
 
-In order to contribute with to this blog, you have two prerequisites:
+In order to contribute to this blog, there are two prerequisites:
 
 1. Create an author page
 2. Write a post
@@ -44,17 +44,17 @@ Content of my personal page in _markdown_ **syntax**
 * `github`: your github handle
 * `discord`: your discord username
 * `reddit`: your reddit username
-* `langs`, `frameworks` and `misc`: refer to next section.
+* `langs`, `frameworks` and `misc`: your skills, refer to the next section.
 
 `layout`, `short_name` and `name` are mandatory. Everything else is optional.
 
-At the end of the page content, a list of your posts will be shown. This list is retrieved by your `short_name`, so be sure to put _that_ as post's `author`.
+At the end of the page content, a skill table and a list of your posts will be shown. The skill table is compiled with the skills in your YAML frontmatter. The post list is retrieved by your `short_name`, so be sure to put _that_ as post's `author`.
 
 Refer to `_authors/slaierno.md` as an example to build your own author page.
 
 ### `langs`, `frameworks` and `misc`
 
-Each one of such variable works like the other. We will refer to `langs` with this in mind.
+Each one of such variables works like the other. We will refer to `langs` with this in mind.
 
 * `name` short name of the skill. Those names can be found in `_data/skillset.yml`
 * `ver` optional list of versions. Available versions can be found in `_data/skillset.yml`
@@ -63,7 +63,7 @@ Each one of such variable works like the other. We will refer to `langs` with th
 
 Remember to put each skill in the correct category (`langs`, `frameworks`, `misc`) as defined in `_data/skillset.yml`.
 
-For each skill, multiple entries can be put if they refer to different version. If a version-less entry is put, this values will be used as default for every non-specified value. E.g.
+For each skill, multiple entries can be put if they refer to different versions. If a version-less entry is put, this values will be used as default for every non-specified value. E.g.
 
 ```yaml
 langs:

--- a/README.MD
+++ b/README.MD
@@ -20,6 +20,18 @@ role: Writer
 github: tdoe
 discord: tdoe#123
 reddit: teddoe
+langs:
+  - name: cpp
+    ver: [11,14]
+    self: 2
+    want: 3
+frameworks:
+  - name: godot
+    want: 2
+misc:
+  - name: 3D
+    self: 1
+    want: 2
 ---
 
 Content of my personal page in _markdown_ **syntax**
@@ -32,12 +44,57 @@ Content of my personal page in _markdown_ **syntax**
 * `github`: your github handle
 * `discord`: your discord username
 * `reddit`: your reddit username
+* `langs`, `frameworks` and `misc`: refer to next section.
 
 `layout`, `short_name` and `name` are mandatory. Everything else is optional.
 
 At the end of the page content, a list of your posts will be shown. This list is retrieved by your `short_name`, so be sure to put _that_ as post's `author`.
 
-Refer to `_authors/slaierno.md` to build your own author page.
+Refer to `_authors/slaierno.md` as an example to build your own author page.
+
+### `langs`, `frameworks` and `misc`
+
+Each one of such variable works like the other. We will refer to `langs` with this in mind.
+
+* `name` short name of the skill. Those names can be found in `_data/skillset.yml`
+* `ver` optional list of versions. Available versions can be found in `_data/skillset.yml`
+* `self` how much an author is capable in a skill. Points go from 0 to 3, default (if absent) is 0
+* `want` how much an author is want to learn a  skill. Points go from 0 to 3, default (if absent) is 0
+
+Remember to put each skill in the correct category (`langs`, `frameworks`, `misc`) as defined in `_data/skillset.yml`.
+
+For each skill, multiple entries can be put if they refer to different version. If a version-less entry is put, this values will be used as default for every non-specified value. E.g.
+
+```yaml
+langs:
+  - name: cpp
+    ver: [11,14]
+    self: 2
+    want: 3
+  - name: cpp
+    self: 1
+    want: 2
+```
+Means that the author has S/W=(2,3) for C++11 and C++14 and S/W=(1,2) for the other available versions (98, 17, 20).  
+Beware that anytime you put a version-specific entry, suche values will override the existing ones. E.g.
+```yaml
+langs:
+  - name: cpp
+    ver: [11,14]
+    want: 3
+  - name: cpp
+    self: 1
+    want: 2
+```
+The first entry specifies versions 11 and 14, but since `self` is skipped, 0 will be assumed and the author will find a skillset like:
+
+| S98 | S11   | S14   | S17 | S20 | W98 | W11 | W14 | W17 | W20 |
+| --- | ----- | ----- | --- | --- | --- | --- | --- | --- | --- |
+| 1   | **0** | **0** | 1   | 1   | 2   | 3   | 3   | 2   | 2   |
+
+### Adding more skills
+
+If you want to add a skill or a skill version, just update `_data/skillset.yml` and you are free to add such skill/version in your personal page.
 
 ## Create a post
 

--- a/_authors/kmfrick.md
+++ b/_authors/kmfrick.md
@@ -5,6 +5,57 @@ name: Kevin Michael Frick
 role: Funnel Chief
 github: kmfrick
 discord: vaporK#7687
+langs:
+  - name: js
+    want: 1
+  - name: python
+    self: 2
+    want: 3
+  - name: java
+    ver: [9]
+    self: 2
+    want: 2
+  - name: cs
+    self: 1
+    want: 1
+  - name: c
+    self: 3
+    want: 3
+  - name: cpp 
+    ver: [11,13]
+    self: 2
+    want: 3
+  - name: lua
+    want: 1
+frameworks:
+  - name: unity
+    want: 1
+  - name: godot
+    want: 2
+  - name: phaser
+    want: 1
+  - name: l2d
+    want: 2
+  - name: irrlicht
+    self: 1
+    want: 3
+  - name: idtech
+    want: 3
+  - name: ogre
+    want: 2
+  - name: osg
+    want: 2
+misc:
+  - name: 3D
+    want: 1
+  - name: agile
+    self: 1
+  - name: devops
+    self: 1
+    want: 2
+  - name: audio
+    self: 2
+    want: 3
 ---
 
 This page is work in progress!

--- a/_authors/slaierno.md
+++ b/_authors/slaierno.md
@@ -6,6 +6,69 @@ role: Funnel Chief
 github: slaierno
 discord: uminoraven#2810
 reddit: srandtimenull
+langs:
+  - name: cpp 
+    ver: [17, 20]
+    self: 2
+    want: 3
+  - name: cpp
+    ver: [11, 14]
+    self: 2
+    want: 2
+  - name: cpp
+    self: 2
+    want: 1
+  - name: c
+    self: 2
+  - name: c
+    ver: [99, 11]
+    self: 3
+  - name: python
+    self: 1
+    want: 2
+  - name: java
+    ver: [7]
+    self: 1
+    want: 1
+  - name: cs
+    self: 1
+    want: 1
+  - name: php
+    want: 1
+  - name: lua
+    want: 1
+  - name: js
+    self: 1
+    want: 2
+frameworks:
+  - name: godot
+    want: 2
+  - name: unreal
+    want: 2
+  - name: unity
+    want: 2
+  - name: phaser
+    want: 1
+  - name: l2d
+    want: 1
+  - name: irrlicht
+    want: 2
+misc:
+  - name: 3D
+    self: 1
+    want: 2
+  - name: 2D
+    self: 1
+    want: 2
+  - name: agile
+    self: 2
+  - name: devops
+    want: 1
+  - name: audio
+    want: 2
+
 ---
 
 This page is work in progress!
+
+

--- a/_authors/ste001.md
+++ b/_authors/ste001.md
@@ -6,6 +6,53 @@ role: Funnel Chief
 github: ste001
 discord: FearTheSock#5197
 reddit: ste001
+langs:
+  - name: php
+    self: 1
+    want: 2
+  - name: js
+    self: 3
+    want: 3
+  - name: python
+    self: 1
+    want: 3
+  - name: java
+    ver: [8]
+    self: 2
+    want: 2
+  - name: cs
+    self: 2
+    want: 3
+  - name: c
+    self: 1
+    want: 1
+  - name: cpp 
+    ver: [11]
+    self: 2
+    want: 2
+  - name: rb
+    self: 2
+    want: 3
+frameworks:
+  - name: unity
+    self: 1
+    want: 2
+  - name: godot
+    self: 1
+    want: 3
+  - name: phaser
+    want: 1
+  - name: l2d
+    want: 2
+misc:
+  - name: 2D
+    want: 2
+  - name: agile
+    self: 2
+    want: 3
+  - name: devops
+    self: 1
+    want: 3
 ---
 
 This page is work in progress!

--- a/_authors/vikkio.md
+++ b/_authors/vikkio.md
@@ -28,7 +28,8 @@ langs:
   - name: c
     self: 1
     want: 1
-  - name: cpp 
+  - name: cpp
+    ver: [98, 11] 
     self: 1
     want: 2
   - name: rb

--- a/_authors/vikkio.md
+++ b/_authors/vikkio.md
@@ -6,6 +6,63 @@ role: Funnel Founder
 github: vikkio88
 discord: 
 reddit: 
+langs:
+  - name: php 
+    self: 3
+    want: 3
+  - name: js 
+    self: 3
+    want: 3
+  - name: python 
+    self: 1
+    want: 3
+  - name: java
+    self: 1
+    want: 2
+  - name: go
+    self: 1
+    want: 3
+  - name: cs
+    self: 1
+    want: 0
+  - name: c
+    self: 1
+    want: 1
+  - name: cpp 
+    self: 1
+    want: 2
+  - name: rb
+    self: 1
+    want: 0
+  - name: haxe
+    self: 0
+    want: 3
+frameworks:
+  - name: unity
+    want: 2
+  - name: pygame
+    want: 2
+  - name: godot
+    self: 1
+    want: 3
+  - name: phaser
+    self: 1
+    want: 3
+  - name: heaps
+    want: 3
+  - name: l2d
+    want: 1
+misc:
+  - name: 2D
+    want: 2
+  - name: agile
+    self: 2
+    want: 3
+  - name: devops
+    self: 1
+    want: 2
+  - name: audio
+    want: 1
 ---
 
 This page is work in progress!

--- a/_data/skillset.yml
+++ b/_data/skillset.yml
@@ -50,6 +50,12 @@ frameworks:
     name: "Love2D"
   irrlicht:
     name: "Irrlicht"
+  idtech:
+    name: "id Tech"
+  ogre:
+    name: "OGRE 3D"
+  osg:
+    name: "OpenSceneGraph"
 
 misc:
   3D:

--- a/_data/skillset.yml
+++ b/_data/skillset.yml
@@ -1,0 +1,64 @@
+titles:
+  langs: "Languages"
+  frameworks: "Frameworks"
+  misc: "Miscellaneous"
+
+langs:
+  cpp:
+    name: "C++"
+    vers: [98, 11, 14, 17, 20]
+  c:
+    name: "C"
+    vers: [89, 99, 11]
+  python:
+    name: "Python"
+    vers: [2, 3]
+  php:
+    name: "PHP"
+  js:
+    name: "Javascript"
+  java:
+    name: "Java"
+    vers: [7,8,9,10,11]
+  go:
+    name: "Go"
+  cs:
+    name: "C#"
+  lua:
+    name: "Lua"
+  clj:
+    name: "Clojure"
+  rb:
+    name: "Ruby"
+  hx:
+    name: "Haxe"
+
+frameworks:
+  godot:
+    name: "Godot"
+  unreal:
+    name: "Unreal Engine"
+  unity:
+    name: "Unity"
+  pygame:
+    name: "PyGame"
+  phaser:
+    name: "Phaser.js"
+  heaps:
+    name: "Heaps"
+  l2d:
+    name: "Love2D"
+  irrlicht:
+    name: "Irrlicht"
+
+misc:
+  3D:
+    name: "3D Graphics"
+  2D:
+    name: "2D Graphics"
+  agile:
+    name: "AGILE/SCRUM"
+  devops:
+    name: "DevOps"
+  audio:
+    name: "Audio"

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -14,7 +14,7 @@ layout: default
 <table>
 <tr>
 {% for lang in page.langs -%}
-<th colspan="2"> {{ site.data.skillset[lang.name].name }} {%- if lang.ver -%} ({{lang.ver | join: ","}}) {%- endif -%} </th>
+<th colspan="2"> {{ site.data.skillset["langs"][lang.name].name }} {%- if lang.ver -%} ({{lang.ver | join: ","}}) {%- endif -%} </th>
 {%- endfor %}
 </tr>
 <tr>
@@ -38,7 +38,7 @@ layout: default
 <table>
 <tr>
 {% for fw in page.frameworks -%}
-<th colspan="2"> {{ site.data.skillset[fw.name].name }} {%- if fw.ver -%} ({{fw.ver | join: ","}}) {%- endif -%} </th>
+<th colspan="2"> {{ site.data.skillset["frameworks"][fw.name].name }} {%- if fw.ver -%} ({{fw.ver | join: ","}}) {%- endif -%} </th>
 {%- endfor %}
 </tr>
 <tr>
@@ -62,7 +62,7 @@ layout: default
 <table>
 <tr>
 {% for skill in page.misc -%}
-<th colspan="2"> {{ site.data.skillset[skill.name].name }} {%- if skill.ver -%} ({{skill.ver | join: ","}}) {%- endif -%} </th>
+<th colspan="2"> {{ site.data.skillset["misc"][skill.name].name }} {%- if skill.ver -%} ({{skill.ver | join: ","}}) {%- endif -%} </th>
 {%- endfor %}
 </tr>
 <tr>

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -6,6 +6,81 @@ layout: default
 
 {{ content }}
 
+
+<h2> Skillset</h2>
+
+<h3>Languages</h3>
+
+<table>
+<tr>
+{% for lang in page.langs -%}
+<th colspan="2"> {{ site.data.skillset[lang.name].name }} {%- if lang.ver -%} ({{lang.ver | join: ","}}) {%- endif -%} </th>
+{%- endfor %}
+</tr>
+<tr>
+{% for lang in page.langs -%}
+{% if lang.self and lang.want %} {% assign cs = 1 %} {% else %} {% assign cs = 2 %} {% endif %}
+{% if lang.self %}<th colspan="{{cs}}">Self</th>{% endif %}
+{% if lang.want %}<th colspan="{{cs}}">Want</th>{% endif %}
+{%- endfor %}
+</tr>
+<tr>
+{% for lang in page.langs -%}
+{% if lang.self and lang.want %} {% assign cs = 1 %} {% else %} {% assign cs = 2 %} {% endif %}
+{% if lang.self %}<td colspan="{{cs}}">{{lang.self}}</td>{% endif %}
+{% if lang.want %}<td colspan="{{cs}}">{{lang.want}}</td>{% endif %}
+{%- endfor %}
+</tr>
+</table>
+
+<h3>Frameworks</h3>
+
+<table>
+<tr>
+{% for fw in page.frameworks -%}
+<th colspan="2"> {{ site.data.skillset[fw.name].name }} {%- if fw.ver -%} ({{fw.ver | join: ","}}) {%- endif -%} </th>
+{%- endfor %}
+</tr>
+<tr>
+{% for fw in page.frameworks -%}
+{% if fw.self and fw.want %} {% assign cs = 1 %} {% else %} {% assign cs = 2 %} {% endif %}
+{% if fw.self %}<th colspan="{{cs}}">Self</th>{% endif %}
+{% if fw.want %}<th colspan="{{cs}}">Want</th>{% endif %}
+{%- endfor %}
+</tr>
+<tr>
+{% for fw in page.frameworks -%}
+{% if fw.self and fw.want %} {% assign cs = 1 %} {% else %} {% assign cs = 2 %} {% endif %}
+{% if fw.self %}<td colspan="{{cs}}">{{fw.self}}</td>{% endif %}
+{% if fw.want %}<td colspan="{{cs}}">{{fw.want}}</td>{% endif %}
+{%- endfor %}
+</tr>
+</table>
+
+<h3>Miscellaneous</h3>
+
+<table>
+<tr>
+{% for skill in page.misc -%}
+<th colspan="2"> {{ site.data.skillset[skill.name].name }} {%- if skill.ver -%} ({{skill.ver | join: ","}}) {%- endif -%} </th>
+{%- endfor %}
+</tr>
+<tr>
+{% for skill in page.misc -%}
+{% if skill.self and skill.want %} {% assign cs = 1 %} {% else %} {% assign cs = 2 %} {% endif %}
+{% if skill.self %}<th colspan="{{cs}}">Self</th>{% endif %}
+{% if skill.want %}<th colspan="{{cs}}">Want</th>{% endif %}
+{%- endfor %}
+</tr>
+<tr>
+{% for skill in page.misc -%}
+{% if skill.self and skill.want %} {% assign cs = 1 %} {% else %} {% assign cs = 2 %} {% endif %}
+{% if skill.self %}<td colspan="{{cs}}">{{skill.self}}</td>{% endif %}
+{% if skill.want %}<td colspan="{{cs}}">{{skill.want}}</td>{% endif %}
+{%- endfor %}
+</tr>
+</table>
+
 <h2>Posts</h2>
 <ul>
   {% assign filtered_posts = site.posts | where: 'author', page.short_name %}

--- a/skills.md
+++ b/skills.md
@@ -72,7 +72,7 @@ title: Skills
                 {%- endunless -%}
 
                 <tr>
-                    <td>{{author.name}}</td>
+                    <td><a href="{{author.url}}">{{author.name}}</a></td>
                 {%- for type in self_want -%}
                     {%- if skill.vers -%}
                         {%- for ver in skill.vers -%}

--- a/skills.md
+++ b/skills.md
@@ -14,7 +14,7 @@ title: Skills
         {%- assign skill = skill_[1] -%} {%- comment -%} possible skill-related skills {%- endcomment -%}
 
         {%- comment -%} Search if there is at least an author holding skills for this skill
-                        and continues to next skill if there is noone {%- endcomment -%}
+                        and continues to next skill if there is no one {%- endcomment -%}
         {%- assign skill_found = false -%}
         {%- for author in site.authors -%}
             {%- for a_skill in author[stype] -%}
@@ -106,21 +106,6 @@ title: Skills
                                 {%- endunless -%}
                                 {%- assign score = skill_found[type] -%}
                             {%- endif -%}
-{%-comment-%} This is disabled but we will keep it here for backup reason
-                            {%- if skill_found.ver -%}
-                                {%- if skill_found[type] -%}
-                                    {%- for a_ver in skill_found.ver -%}
-                                        {%- if a_ver == ver -%}
-                                            {%- assign score = skill_found[type] -%}
-                                            {%- break -%}
-                                        {%- endif -%}
-                                    {%- endfor -%}
-                                {%- endif -%}
-                            {%- else -%}
-                                {%- assign score = skill_found[type] -%}
-                            {%- endif -%}
-{%- endcomment -%}
-
                             <td>{%- if score > 0 -%} {{score}} {%- endif -%}</td>
                         {%- endfor -%}
                     {%- else -%}

--- a/skills.md
+++ b/skills.md
@@ -1,0 +1,138 @@
+---
+title: Skills
+---
+
+{%- assign langs_framework_misc = "langs,frameworks,misc" | split: "," -%}
+{%- assign self_want = "self,want" | split: "," -%}
+
+{% for stype in langs_framework_misc -%}
+
+<h1> {{ site.data.skillset["titles"][stype] }} </h1>
+
+    {%- for skill_ in site.data.skillset[stype] -%}
+        {%- assign skill_name = skill_[0] -%} {%- comment -%} skill name we are searching for {%- endcomment -%}
+        {%- assign skill = skill_[1] -%} {%- comment -%} possible skill-related skills {%- endcomment -%}
+
+        {%- comment -%} Search if there is at least an author holding skills for this skill
+                        and continues to next skill if there is noone {%- endcomment -%}
+        {%- assign skill_found = false -%}
+        {%- for author in site.authors -%}
+            {%- for a_skill in author[stype] -%}
+                {%- if a_skill.name == skill_name -%}
+                    {%- assign skill_found = a_skill -%}
+                    {%- break -%}
+                {%- endif -%}
+            {%- endfor -%}
+        {%- endfor -%}
+        {%- unless skill_found -%}
+            {%- continue -%}
+        {%- endunless -%}
+
+        <h2> {{ skill.name }} </h2>
+
+        {%- comment -%} The number of possible versions will determine rowspan and colspan {%- endcomment -%}
+        {%- assign ver_cnt = skill.vers.size -%}
+        {%- if ver_cnt > 1 -%}
+        {%- assign rspan = 2 -%}
+        {%- assign cspan = ver_cnt -%}
+        {%- else -%}
+        {%- assign rspan = 1 -%}
+        {%- assign cspan = 1 -%}
+        {%- endif -%}
+
+        <table>
+            <tr>
+                <th rowspan="{{rspan}}"> Person </th>
+                <th colspan="{{cspan}}"> Self </th>
+                <th colspan="{{cspan}}"> Want </th>
+            </tr>
+        {%- comment -%} If there are more versions, print a column for each one {%- endcomment -%}
+        {%- if ver_cnt > 1 -%}
+            <tr>
+            {%- for type in self_want -%}
+                {%- for ver in skill.vers -%}
+                    <th> {{ver}} </th>
+                {%- endfor -%}
+            {%- endfor -%}
+            </tr>
+        {%- endif -%}
+
+            {%- for author in site.authors -%}
+
+                {%- comment -%} Check if skill_name is found inside the author skill list, continue otherwise {%- endcomment -%}
+                {%- assign skill_found = false -%}
+                {%- for a_skill in author[stype] -%}
+                    {%- if a_skill.name == skill_name -%}
+                        {%- assign skill_found = a_skill -%}
+                        {%- break -%}
+                    {%- endif -%}
+                {%- endfor -%}
+                {%- unless skill_found -%}
+                    {%- continue -%}
+                {%- endunless -%}
+
+                <tr>
+                    <td>{{author.name}}</td>
+                {%- for type in self_want -%}
+                    {%- if skill.vers -%}
+                        {%- for ver in skill.vers -%}
+                            {%- assign score = 0 -%}
+
+{%- comment -%} returns score for matching (skill_name, ver). If no matching version is available but
+                there is a versionless entry, such score will be used {%- endcomment -%}
+                            {%- assign skill_list = author[stype] -%}
+                            {%- assign skill_found = false -%}
+                            {%- assign skill_found_generic = false -%}
+                            {%- for a_skill in skill_list -%}
+                                {%- if a_skill.name == skill_name -%}
+                                    {% if a_skill.ver%}
+                                        {%- for a_ver in a_skill.ver -%}
+                                            {%- if a_ver == ver -%}
+                                                {%- assign skill_found = a_skill -%}
+                                                {%- break -%}
+                                            {%- endif -%}
+                                        {%- endfor -%}
+                                    {%- else -%}
+                                        {%- assign skill_found_generic = a_skill -%}
+                                    {%- endif -%}
+                                {%- endif -%}
+                                {%- if skill_found -%}
+                                    {%- break -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {%- if skill_found or skill_found_generic -%}
+                                {%- unless skill_found -%}
+                                    {%- assign skill_found = skill_found_generic -%}
+                                {%- endunless -%}
+                                {%- assign score = skill_found[type] -%}
+                            {%- endif -%}
+{%-comment-%} This is disabled but we will keep it here for backup reason
+                            {%- if skill_found.ver -%}
+                                {%- if skill_found[type] -%}
+                                    {%- for a_ver in skill_found.ver -%}
+                                        {%- if a_ver == ver -%}
+                                            {%- assign score = skill_found[type] -%}
+                                            {%- break -%}
+                                        {%- endif -%}
+                                    {%- endfor -%}
+                                {%- endif -%}
+                            {%- else -%}
+                                {%- assign score = skill_found[type] -%}
+                            {%- endif -%}
+{%- endcomment -%}
+
+                            <td>{%- if score > 0 -%} {{score}} {%- endif -%}</td>
+                        {%- endfor -%}
+                    {%- else -%}
+                        {%- assign score = skill_found[type] -%}
+                        <td>{%- if score > 0 -%} {{score}} {%- endif -%}</td>
+                    {%- endif -%}
+                {%- endfor -%}
+                </tr>
+            {%- endfor -%}
+        </table>
+
+    {%-endfor-%}
+------
+------
+{%endfor%}

--- a/team.md
+++ b/team.md
@@ -3,7 +3,7 @@ layout: page
 title: Team
 permalink: /team/
 ---
-    
+
 {% assign sorted = site.authors | sort: 'name' %}
 | Name | Role  | Github | Discord | Reddit |
 | :--- | :---: | :----: | :-----: | :----: |


### PR DESCRIPTION
Please, try to build this locally before merging in order to have a visual preview.

Author page's skill list may be enhanced. As for now, tables can get too long and pretty ugly, but I just got tired of messing up with Liquid metaprogramming and gave up on that side.

The new table can be viewed at any personal page and on the new page "Skills" accessible from the top bar.